### PR TITLE
chore: Bump version to 0.0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bunary/orm",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "ORM for Bunary - a Bun-first backend framework inspired by Laravel",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Bump package version to 0.0.5 to include the global registry fix for reading config from @bunary/core.

## Changes
- Version bump: 0.0.4 → 0.0.5

## Includes
- Updated `tryGetCoreConfig()` to use `__bunaryCoreConfig` global registry first
- More reliable than dynamic module loading methods
- Falls back to other methods if registry not available

Closes #9