### PR TITLE
docs: add docs directory for canonical package documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ ORM for Bunary - a Bun-first backend framework inspired by Laravel Eloquent.
 
 Features a database abstraction layer that supports multiple database types through a unified API.
 
+## Documentation
+
+Canonical documentation for this package lives in [`docs/index.md`](./docs/index.md).
+
 ## Installation
 
 ```bash

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,31 @@
+# @bunary/orm
+
+ORM for Bunary — a Bun-first backend framework inspired by Laravel Eloquent.
+
+## Installation
+
+```bash
+bun add @bunary/orm
+```
+
+## Quickstart
+
+```ts
+import { Model, setOrmConfig } from "@bunary/orm";
+
+setOrmConfig({
+  database: {
+    type: "sqlite",
+    sqlite: {
+      path: "./database.sqlite",
+    },
+  },
+});
+
+const user = await Model.table("users").find(1);
+```
+
+## Requirements
+
+- Bun ≥ 1.0.0
+


### PR DESCRIPTION
## Summary
- Add `docs/index.md` as the canonical documentation entry for `@bunary/orm`.
- Update the README to point to the `docs/` directory.

## Test plan
- N/A (documentation only)

Closes #19