### PR TITLE
feat: Driver registry API for third-party database providers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,10 @@
 name: CI
 
+# CI uses latest Bun version to catch issues early.
+# Developers should keep local Bun updated: `bun upgrade`
+# Check outdated packages: `bun outdated`
+# Update specific package: `bun update [package]`
+
 on:
   push:
     branches: [main]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.6] - 2026-01-29
+
+### Added
+
+- **Driver Registry API** - Extension point for third-party database providers
+  - `registerDriver(type, factory)` - Register custom database driver factories
+  - `DriverFactory` type - Type definition for driver factory functions
+  - `clearDriverRegistry()` - Clear all registered drivers (useful for testing)
+  - Registered drivers take precedence over built-in drivers
+  - Allows third-party packages to add support for additional database types (e.g., PostgreSQL, Supabase) without modifying core code
+  - Example: `registerDriver("postgres", (config) => new PostgresDriver(config.postgres!))`
+
+### Changed
+
+- `createDriver()` now checks the driver registry before falling back to built-in drivers
+- Improved error message for unsupported database types to suggest using `registerDriver()`
+
 ## [0.0.2] - 2026-01-26
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -372,6 +372,39 @@ The MySQL driver structure is in place. To implement:
 
 PostgreSQL support will follow the same pattern as MySQL.
 
+### Custom Drivers (Third-Party Registry)
+
+Third-party packages can register custom database drivers using the driver registry API:
+
+```typescript
+import { registerDriver, createDriver, type DriverFactory } from "@bunary/orm";
+import type { DatabaseConfig, DatabaseDriver } from "@bunary/orm";
+
+// Define your custom driver
+class PostgresDriver implements DatabaseDriver {
+  // ... implement DatabaseDriver interface
+}
+
+// Register the driver factory
+const factory: DriverFactory = (config: DatabaseConfig) => {
+  return new PostgresDriver(config.postgres!);
+};
+
+registerDriver("postgres", factory);
+
+// Now you can use it in your config
+setOrmConfig({
+  database: {
+    type: "postgres",
+    postgres: {
+      // your postgres config
+    }
+  }
+});
+```
+
+**Note:** Registered drivers take precedence over built-in drivers, allowing you to override default implementations if needed.
+
 ## Advanced Usage
 
 ### Direct Driver Access

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,6 +25,47 @@ setOrmConfig({
 const user = await Model.table("users").find(1);
 ```
 
+## Driver Registry API
+
+Third-party packages can register custom database drivers using the driver registry API:
+
+```ts
+import { registerDriver, type DriverFactory } from "@bunary/orm";
+import type { DatabaseConfig, DatabaseDriver } from "@bunary/orm";
+
+// Define your custom driver
+class PostgresDriver implements DatabaseDriver {
+  query(sql: string, ...params: unknown[]) {
+    // Implement query logic
+  }
+  exec(sql: string, ...params: unknown[]) {
+    // Implement exec logic
+  }
+  close() {
+    // Implement close logic
+  }
+}
+
+// Register the driver factory
+const factory: DriverFactory = (config: DatabaseConfig) => {
+  return new PostgresDriver(config.postgres!);
+};
+
+registerDriver("postgres", factory);
+
+// Now you can use it in your config
+setOrmConfig({
+  database: {
+    type: "postgres",
+    postgres: {
+      // your postgres config
+    }
+  }
+});
+```
+
+Registered drivers take precedence over built-in drivers, allowing you to override default implementations if needed.
+
 ## Requirements
 
 - Bun ≥ 1.0.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bunary/orm",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "ORM for Bunary - a Bun-first backend framework inspired by Laravel",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,7 +51,13 @@ export {
 } from "./config.js";
 
 // Connection Management
-export { createDriver, getDriver } from "./connection.js";
+export {
+	createDriver,
+	getDriver,
+	registerDriver,
+	clearDriverRegistry,
+	type DriverFactory,
+} from "./connection.js";
 
 // Model
 export { Model } from "./model.js";

--- a/tests/registry.test.ts
+++ b/tests/registry.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Driver Registry Tests
+ */
+import { beforeEach, describe, expect, it } from "bun:test";
+import {
+	clearDriverRegistry,
+	createDriver,
+	registerDriver,
+} from "../src/connection.js";
+import type { DatabaseDriver } from "../src/drivers/types.js";
+import type { DatabaseConfig } from "../src/types.js";
+
+describe("Driver Registry", () => {
+	beforeEach(() => {
+		// Clear registry before each test
+		clearDriverRegistry();
+	});
+
+	describe("registerDriver()", () => {
+		it("should register a custom driver factory", () => {
+			const mockDriver: DatabaseDriver = {
+				query: () => ({
+					all: () => [],
+					get: () => null,
+				}),
+				exec: () => 0,
+				close: () => {},
+			};
+
+			const factory = (config: DatabaseConfig) => {
+				expect(config.type as string).toBe("custom");
+				return mockDriver;
+			};
+
+			registerDriver("custom", factory);
+
+			const config = {
+				type: "custom",
+			} as unknown as DatabaseConfig;
+
+			const driver = createDriver(config);
+			expect(driver).toBe(mockDriver);
+		});
+
+		it("should allow overriding built-in drivers", () => {
+			const mockSqliteDriver: DatabaseDriver = {
+				query: () => ({
+					all: () => [{ id: 1, name: "test" }],
+					get: () => ({ id: 1, name: "test" }),
+				}),
+				exec: () => 1,
+				close: () => {},
+			};
+
+			const factory = () => mockSqliteDriver;
+
+			registerDriver("sqlite", factory);
+
+			const config: DatabaseConfig = {
+				type: "sqlite",
+				sqlite: {
+					path: "/tmp/test.sqlite",
+				},
+			};
+
+			const driver = createDriver(config);
+			expect(driver).toBe(mockSqliteDriver);
+			expect(driver.query("SELECT * FROM users").all()).toEqual([
+				{ id: 1, name: "test" },
+			]);
+		});
+
+		it("should throw error when registering invalid factory", () => {
+			expect(() => {
+				registerDriver("invalid", null as unknown as () => DatabaseDriver);
+			}).toThrow("must be a function");
+		});
+	});
+
+	describe("createDriver() with registry", () => {
+		it("should use registered driver when available", () => {
+			const customDriver: DatabaseDriver = {
+				query: () => ({
+					all: () => [],
+					get: () => null,
+				}),
+				exec: () => 0,
+				close: () => {},
+			};
+
+			registerDriver("postgres", () => customDriver);
+
+			const config: DatabaseConfig = {
+				type: "postgres",
+			};
+
+			const driver = createDriver(config);
+			expect(driver).toBe(customDriver);
+		});
+
+		it("should fall back to built-in drivers when not registered", () => {
+			const config: DatabaseConfig = {
+				type: "sqlite",
+				sqlite: {
+					path: "/tmp/test-fallback.sqlite",
+				},
+			};
+
+			// Don't register sqlite, should use built-in
+			const driver = createDriver(config);
+			expect(driver).toBeDefined();
+			expect(typeof driver.query).toBe("function");
+			driver.close();
+		});
+
+		it("should throw error for unknown driver type when not registered", () => {
+			const config = {
+				type: "unknown",
+			} as unknown as DatabaseConfig;
+
+			expect(() => createDriver(config)).toThrow("not supported");
+		});
+	});
+
+	describe("Registry isolation", () => {
+		it("should support multiple driver registrations", () => {
+			const driver1: DatabaseDriver = {
+				query: () => ({
+					all: () => [],
+					get: () => null,
+				}),
+				exec: () => 0,
+				close: () => {},
+			};
+
+			const driver2: DatabaseDriver = {
+				query: () => ({
+					all: () => [],
+					get: () => null,
+				}),
+				exec: () => 0,
+				close: () => {},
+			};
+
+			registerDriver("type1", () => driver1);
+			registerDriver("type2", () => driver2);
+
+			const config1 = { type: "type1" } as unknown as DatabaseConfig;
+			const config2 = { type: "type2" } as unknown as DatabaseConfig;
+
+			expect(createDriver(config1)).toBe(driver1);
+			expect(createDriver(config2)).toBe(driver2);
+		});
+	});
+});


### PR DESCRIPTION
Implements feature #18 - Driver registry API for third-party database providers.

## Changes

- **Added `registerDriver(type, factory)`** - Register custom database driver factories
- **Added `DriverFactory` type** - Type definition for driver factory functions  
- **Added `clearDriverRegistry()`** - Clear all registered drivers (useful for testing)
- **Updated `createDriver()`** - Now checks registry before falling back to built-in drivers
- Registered drivers take precedence over built-in drivers
- Support for any database type (not limited to built-in DatabaseType)

## Testing

- Added comprehensive test suite (7 new tests)
- All 145 tests passing
- Tests cover: custom driver registration, overriding built-in drivers, error handling, registry isolation

## Documentation

- Updated README.md with "Custom Drivers (Third-Party Registry)" section
- Updated docs/index.md with driver registry API examples
- Updated CHANGELOG.md for v0.0.6

## Example Usage

```ts
import { registerDriver, type DriverFactory } from "@bunary/orm";
import type { DatabaseConfig, DatabaseDriver } from "@bunary/orm";

class PostgresDriver implements DatabaseDriver {
  // ... implement DatabaseDriver interface
}

const factory: DriverFactory = (config: DatabaseConfig) => {
  return new PostgresDriver(config.postgres!);
};

registerDriver("postgres", factory);
```

Closes #18
