### PR TITLE
fix: Driver connection reuse - cache driver instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.7] - 2026-01-29
+
+### Fixed
+
+- **Driver Connection Reuse** - `getDriver()` now caches and reuses driver instances
+  - Repeated calls to `getDriver()` return the same driver instance for the same config
+  - Reduces connection overhead and enables transaction coordination
+  - Cache automatically invalidates when configuration changes
+  - Added `closeDriver()` to explicitly close the cached driver connection
+  - Added `resetDriver()` to clear cache without closing (useful for testing)
+
+### Changed
+
+- `getDriver()` now caches driver instances based on configuration hash
+- Driver cache is automatically cleared when `setOrmConfig()` is called with different config
+
 ## [0.0.6] - 2026-01-29
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -419,6 +419,26 @@ const result = driver.query("SELECT * FROM users WHERE id = ?", 1);
 const user = result.get();
 ```
 
+### Driver Connection Management
+
+The ORM caches driver instances for connection reuse. `getDriver()` returns the same driver instance when called multiple times with the same configuration, reducing connection overhead.
+
+```typescript
+import { getDriver, closeDriver, resetDriver } from "@bunary/orm";
+
+// Get driver (cached after first call)
+const driver1 = getDriver();
+const driver2 = getDriver(); // Returns same instance as driver1
+
+// Explicitly close the cached driver
+closeDriver(); // Closes connection and clears cache
+
+// Reset cache without closing (useful for testing)
+resetDriver(); // Clears cache, next getDriver() creates new instance
+```
+
+**Note:** The driver cache is automatically invalidated when the configuration changes, ensuring you always get a driver matching the current config.
+
 ## Requirements
 
 - Bun ≥ 1.0.0

--- a/docs/index.md
+++ b/docs/index.md
@@ -66,6 +66,26 @@ setOrmConfig({
 
 Registered drivers take precedence over built-in drivers, allowing you to override default implementations if needed.
 
+## Driver Connection Management
+
+The ORM caches driver instances for connection reuse. `getDriver()` returns the same driver instance when called multiple times with the same configuration, reducing connection overhead.
+
+```ts
+import { getDriver, closeDriver, resetDriver } from "@bunary/orm";
+
+// Get driver (cached after first call)
+const driver1 = getDriver();
+const driver2 = getDriver(); // Returns same instance as driver1
+
+// Explicitly close the cached driver
+closeDriver(); // Closes connection and clears cache
+
+// Reset cache without closing (useful for testing)
+resetDriver(); // Clears cache, next getDriver() creates new instance
+```
+
+The driver cache is automatically invalidated when the configuration changes, ensuring you always get a driver matching the current config.
+
 ## Requirements
 
 - Bun ≥ 1.0.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bunary/orm",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "ORM for Bunary - a Bun-first backend framework inspired by Laravel",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,6 +56,8 @@ export {
 	getDriver,
 	registerDriver,
 	clearDriverRegistry,
+	closeDriver,
+	resetDriver,
 	type DriverFactory,
 } from "./connection.js";
 

--- a/tests/driver-cache.test.ts
+++ b/tests/driver-cache.test.ts
@@ -1,0 +1,244 @@
+/**
+ * Driver Caching and Reuse Tests
+ */
+import { beforeEach, describe, expect, it } from "bun:test";
+import {
+	clearOrmConfig,
+	closeDriver,
+	getDriver,
+	resetDriver,
+	setOrmConfig,
+} from "../src/index.js";
+
+describe("Driver Caching and Reuse", () => {
+	beforeEach(() => {
+		// Clear config and driver cache before each test
+		clearOrmConfig();
+		resetDriver();
+	});
+
+	describe("getDriver() caching", () => {
+		it("should return the same driver instance on repeated calls", () => {
+			setOrmConfig({
+				database: {
+					type: "sqlite" as const,
+					sqlite: {
+						path: "/tmp/test-cache.sqlite",
+					},
+				},
+			});
+
+			const driver1 = getDriver();
+			const driver2 = getDriver();
+			const driver3 = getDriver();
+
+			expect(driver1).toBe(driver2);
+			expect(driver2).toBe(driver3);
+			expect(driver1).toBe(driver3);
+
+			driver1.close();
+		});
+
+		it("should return the same driver instance for the same config", () => {
+			const config = {
+				database: {
+					type: "sqlite" as const,
+					sqlite: {
+						path: "/tmp/test-same-config.sqlite",
+					},
+				},
+			};
+
+			setOrmConfig(config);
+			const driver1 = getDriver();
+
+			setOrmConfig(config);
+			const driver2 = getDriver();
+
+			expect(driver1).toBe(driver2);
+
+			driver1.close();
+		});
+	});
+
+	describe("Config change invalidation", () => {
+		it("should create new driver when config changes", () => {
+			setOrmConfig({
+				database: {
+					type: "sqlite" as const,
+					sqlite: {
+						path: "/tmp/test-config1.sqlite",
+					},
+				},
+			});
+
+			const driver1 = getDriver();
+
+			setOrmConfig({
+				database: {
+					type: "sqlite" as const,
+					sqlite: {
+						path: "/tmp/test-config2.sqlite",
+					},
+				},
+			});
+
+			const driver2 = getDriver();
+
+			expect(driver1).not.toBe(driver2);
+
+			driver1.close();
+			driver2.close();
+		});
+
+		it("should create new driver when database type changes", () => {
+			setOrmConfig({
+				database: {
+					type: "sqlite" as const,
+					sqlite: {
+						path: "/tmp/test-type1.sqlite",
+					},
+				},
+			});
+
+			const driver1 = getDriver();
+
+			// Change to different path (same type)
+			setOrmConfig({
+				database: {
+					type: "sqlite" as const,
+					sqlite: {
+						path: "/tmp/test-type2.sqlite",
+					},
+				},
+			});
+
+			const driver2 = getDriver();
+
+			expect(driver1).not.toBe(driver2);
+
+			driver1.close();
+			driver2.close();
+		});
+	});
+
+	describe("closeDriver()", () => {
+		it("should close the cached driver", () => {
+			setOrmConfig({
+				database: {
+					type: "sqlite" as const,
+					sqlite: {
+						path: "/tmp/test-close.sqlite",
+					},
+				},
+			});
+
+			const driver1 = getDriver();
+			closeDriver();
+
+			// After closing, getDriver() should create a new instance
+			const driver2 = getDriver();
+
+			expect(driver1).not.toBe(driver2);
+
+			driver2.close();
+		});
+
+		it("should be safe to call closeDriver() multiple times", () => {
+			setOrmConfig({
+				database: {
+					type: "sqlite" as const,
+					sqlite: {
+						path: "/tmp/test-close-multiple.sqlite",
+					},
+				},
+			});
+
+			getDriver();
+			closeDriver();
+			expect(() => closeDriver()).not.toThrow();
+		});
+
+		it("should be safe to call closeDriver() when no driver is cached", () => {
+			expect(() => closeDriver()).not.toThrow();
+		});
+	});
+
+	describe("resetDriver()", () => {
+		it("should clear the cached driver without closing it", () => {
+			setOrmConfig({
+				database: {
+					type: "sqlite" as const,
+					sqlite: {
+						path: "/tmp/test-reset.sqlite",
+					},
+				},
+			});
+
+			const driver1 = getDriver();
+			resetDriver();
+
+			// After reset, getDriver() should create a new instance
+			const driver2 = getDriver();
+
+			expect(driver1).not.toBe(driver2);
+
+			// Original driver should still be usable (not closed)
+			expect(() => driver1.query("SELECT 1")).not.toThrow();
+
+			driver1.close();
+			driver2.close();
+		});
+
+		it("should be safe to call resetDriver() multiple times", () => {
+			setOrmConfig({
+				database: {
+					type: "sqlite" as const,
+					sqlite: {
+						path: "/tmp/test-reset-multiple.sqlite",
+					},
+				},
+			});
+
+			getDriver();
+			resetDriver();
+			expect(() => resetDriver()).not.toThrow();
+		});
+
+		it("should be safe to call resetDriver() when no driver is cached", () => {
+			expect(() => resetDriver()).not.toThrow();
+		});
+	});
+
+	describe("Integration with config changes", () => {
+		it("should handle config change after resetDriver()", () => {
+			setOrmConfig({
+				database: {
+					type: "sqlite" as const,
+					sqlite: {
+						path: "/tmp/test-integration1.sqlite",
+					},
+				},
+			});
+
+			const driver1 = getDriver();
+			resetDriver();
+
+			setOrmConfig({
+				database: {
+					type: "sqlite" as const,
+					sqlite: {
+						path: "/tmp/test-integration2.sqlite",
+					},
+				},
+			});
+
+			const driver2 = getDriver();
+
+			expect(driver1).not.toBe(driver2);
+
+			driver1.close();
+			driver2.close();
+		});
+	});
+});


### PR DESCRIPTION
Fixes issue #14 - Driver connection reuse by caching driver instances.

## Problem

`getDriver()` was creating a new driver instance on every call, which:
- Created unnecessary connections/resources
- Made it difficult to coordinate transactions across multiple operations
- Complicated migrations (runner should use one connection/transaction scope)

## Solution

- **Driver Instance Caching** - `getDriver()` now caches driver instances based on configuration hash
- **Automatic Cache Invalidation** - Cache is automatically cleared when configuration changes
- **Explicit Control** - Added `closeDriver()` and `resetDriver()` for explicit cache management

## Changes

- **Cached `getDriver()`** - Returns same driver instance for repeated calls with same config
- **Added `closeDriver()`** - Explicitly closes cached driver connection and clears cache
- **Added `resetDriver()`** - Clears cache without closing (useful for testing)
- **Config change detection** - Automatically invalidates cache when `setOrmConfig()` is called with different config

## Testing

- Added comprehensive test suite (11 new tests)
- All 156 tests passing
- Tests cover: caching behavior, config change invalidation, close/reset functions, edge cases

## Documentation

- Updated README.md with "Driver Connection Management" section
- Updated docs/index.md with connection management examples
- Updated CHANGELOG.md for v0.0.7

## Example Usage

```ts
import { getDriver, closeDriver, resetDriver } from "@bunary/orm";

// Get driver (cached after first call)
const driver1 = getDriver();
const driver2 = getDriver(); // Returns same instance as driver1

// Explicitly close the cached driver
closeDriver(); // Closes connection and clears cache

// Reset cache without closing (useful for testing)
resetDriver(); // Clears cache, next getDriver() creates new instance
```

Closes #14
