### PR TITLE
feat: Schema builder (SQLite) for migrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.9] - 2026-01-29
+
+### Added
+
+- **Schema builder (SQLite)** - DDL for migrations
+  - `Schema.createTable(name, (table) => { ... })` - create table with fluent TableBuilder
+  - `Schema.dropTable(name)` - drop table if exists
+  - `Schema.table(name, (table) => { ... })` - alter table (add columns)
+  - TableBuilder: `increments("id")`, `integer()`, `text()`, `boolean()`, `timestamps()`, `unique()`, `index()`
+  - SQLite implementation emits and executes SQL via the configured driver
+  - Tests cover create/drop/alter, column types, unique, and index
+
 ## [0.0.8] - 2026-01-29
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -445,6 +445,40 @@ await driver.transaction(async (tx) => {
 });
 ```
 
+### Schema Builder (Migrations)
+
+The ORM provides a schema builder for creating and altering tables (SQLite):
+
+```typescript
+import { Schema, setOrmConfig } from "@bunary/orm";
+
+setOrmConfig({
+  database: {
+    type: "sqlite",
+    sqlite: { path: "./database.sqlite" }
+  }
+});
+
+// Create a table
+Schema.createTable("users", (table) => {
+  table.increments("id");
+  table.text("name");
+  table.text("email").unique();
+  table.boolean("active");
+  table.timestamps();
+});
+
+// Alter a table (add columns)
+Schema.table("users", (table) => {
+  table.text("phone");
+});
+
+// Drop a table
+Schema.dropTable("users");
+```
+
+**TableBuilder methods:** `increments("id")`, `integer("col")`, `text("col")`, `boolean("col")`, `timestamps()`, `unique("col")` / `unique(["a", "b"])`, `index("col")` / `index(["a", "b"])`. Use `text("col").unique()` for a unique text column.
+
 ## Advanced Usage
 
 ### Direct Driver Access

--- a/docs/index.md
+++ b/docs/index.md
@@ -126,6 +126,40 @@ await driver.transaction(async (tx) => {
 });
 ```
 
+## Schema Builder (Migrations)
+
+DDL for creating and altering tables (SQLite):
+
+```ts
+import { Schema, setOrmConfig } from "@bunary/orm";
+
+setOrmConfig({
+  database: {
+    type: "sqlite",
+    sqlite: { path: "./database.sqlite" },
+  },
+});
+
+// Create a table
+Schema.createTable("users", (table) => {
+  table.increments("id");
+  table.text("name");
+  table.text("email").unique();
+  table.boolean("active");
+  table.timestamps();
+});
+
+// Alter a table (add columns)
+Schema.table("users", (table) => {
+  table.text("phone");
+});
+
+// Drop a table
+Schema.dropTable("users");
+```
+
+TableBuilder: `increments("id")`, `integer()`, `text()`, `boolean()`, `timestamps()`, `unique()`, `index()`.
+
 ## Requirements
 
 - Bun ≥ 1.0.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bunary/orm",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "ORM for Bunary - a Bun-first backend framework inspired by Laravel",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,6 +65,10 @@ export {
 export { Model } from "./model.js";
 export { BaseModel } from "./basemodel.js";
 
+// Schema builder
+export { Schema } from "./schema/index.js";
+export type { TableBuilder, TableBuilderCallback } from "./schema/index.js";
+
 // Database Drivers
 export { SqliteDriver, MysqlDriver } from "./drivers/index.js";
 export type { DatabaseDriver, QueryResult } from "./drivers/types.js";

--- a/src/schema/index.ts
+++ b/src/schema/index.ts
@@ -1,0 +1,10 @@
+/**
+ * Schema builder exports
+ */
+export { Schema } from "./schema.js";
+export { SqliteTableBuilder } from "./sqlite-table-builder.js";
+export type {
+	ColumnBuilder,
+	TableBuilder,
+	TableBuilderCallback,
+} from "./types.js";

--- a/src/schema/schema.ts
+++ b/src/schema/schema.ts
@@ -1,0 +1,121 @@
+/**
+ * Schema builder API for migrations
+ *
+ * Provides createTable, dropTable, and table (alter) operations.
+ * SQLite implementation emits and executes SQL via the configured driver.
+ */
+
+import { getDriver } from "../connection.js";
+import type { DatabaseDriver } from "../drivers/types.js";
+import { SqliteTableBuilder } from "./sqlite-table-builder.js";
+import type { TableBuilderCallback } from "./types.js";
+
+/**
+ * Schema builder for DDL operations (create/drop/alter tables).
+ *
+ * Uses the currently configured driver (from getDriver()).
+ * For SQLite, produces and executes SQLite-compatible SQL.
+ *
+ * @example
+ * ```ts
+ * import { Schema, setOrmConfig } from "@bunary/orm";
+ *
+ * setOrmConfig({ database: { type: "sqlite", sqlite: { path: "./db.sqlite" } } });
+ *
+ * Schema.createTable("users", (table) => {
+ *   table.increments("id");
+ *   table.text("name");
+ *   table.text("email").unique();
+ *   table.timestamps();
+ * });
+ *
+ * Schema.dropTable("users");
+ * ```
+ */
+export const Schema = {
+	/**
+	 * Create a new table
+	 *
+	 * @param name - Table name
+	 * @param callback - Function that receives a TableBuilder to define columns
+	 * @param driver - Optional driver; uses getDriver() if not provided
+	 *
+	 * @example
+	 * ```ts
+	 * Schema.createTable("users", (table) => {
+	 *   table.increments("id");
+	 *   table.text("name");
+	 *   table.text("email").unique();
+	 *   table.timestamps();
+	 * });
+	 * ```
+	 */
+	createTable(
+		name: string,
+		callback: TableBuilderCallback,
+		driver?: DatabaseDriver,
+	): void {
+		const db = driver ?? getDriver();
+		const builder = new SqliteTableBuilder(name, false);
+		callback(builder);
+
+		const createSql = (builder as SqliteTableBuilder).toCreateSql();
+		db.exec(createSql);
+
+		const indexStatements = (builder as SqliteTableBuilder).toIndexSql();
+		for (const sql of indexStatements) {
+			db.exec(sql);
+		}
+	},
+
+	/**
+	 * Drop a table if it exists
+	 *
+	 * @param name - Table name
+	 * @param driver - Optional driver; uses getDriver() if not provided
+	 *
+	 * @example
+	 * ```ts
+	 * Schema.dropTable("users");
+	 * ```
+	 */
+	dropTable(name: string, driver?: DatabaseDriver): void {
+		const db = driver ?? getDriver();
+		const quoted = `"${name.replace(/"/g, '""')}"`;
+		db.exec(`DROP TABLE IF EXISTS ${quoted}`);
+	},
+
+	/**
+	 * Alter an existing table (minimal: add columns)
+	 *
+	 * @param name - Table name
+	 * @param callback - Function that receives a TableBuilder; only new columns are added
+	 * @param driver - Optional driver; uses getDriver() if not provided
+	 *
+	 * @example
+	 * ```ts
+	 * Schema.table("users", (table) => {
+	 *   table.text("phone");
+	 * });
+	 * ```
+	 */
+	table(
+		name: string,
+		callback: TableBuilderCallback,
+		driver?: DatabaseDriver,
+	): void {
+		const db = driver ?? getDriver();
+		const builder = new SqliteTableBuilder(name, true);
+		callback(builder);
+
+		const columns = (builder as SqliteTableBuilder).getAlterColumns();
+		const quotedTable = `"${name.replace(/"/g, '""')}"`;
+		for (const col of columns) {
+			let def = col.sql;
+			if (col.unique) {
+				def += " UNIQUE";
+			}
+			db.exec(`ALTER TABLE ${quotedTable} ADD COLUMN ${def}`);
+		}
+	},
+};

--- a/src/schema/sqlite-table-builder.ts
+++ b/src/schema/sqlite-table-builder.ts
@@ -1,0 +1,144 @@
+/**
+ * SQLite table builder - collects column definitions and emits SQL
+ */
+
+import type { ColumnBuilder, TableBuilder } from "./types.js";
+
+interface ColumnDef {
+	name: string;
+	sql: string;
+	unique?: boolean;
+}
+
+interface IndexDef {
+	columns: string[];
+	unique?: boolean;
+}
+
+/**
+ * SQLite implementation of TableBuilder
+ * Builds CREATE TABLE / ALTER TABLE SQL for SQLite
+ */
+export class SqliteTableBuilder implements TableBuilder {
+	private columns: ColumnDef[] = [];
+	private indexes: IndexDef[] = [];
+	private uniqueConstraints: string[][] = [];
+	private isAlter = false;
+	private tableName = "";
+
+	constructor(tableName: string, isAlter = false) {
+		this.tableName = tableName;
+		this.isAlter = isAlter;
+	}
+
+	increments(name: string): TableBuilder {
+		this.columns.push({
+			name,
+			sql: `${this.quote(name)} INTEGER PRIMARY KEY AUTOINCREMENT`,
+		});
+		return this;
+	}
+
+	integer(name: string): TableBuilder {
+		this.columns.push({ name, sql: `${this.quote(name)} INTEGER` });
+		return this;
+	}
+
+	text(name: string): ColumnBuilder & TableBuilder {
+		const col: ColumnDef = { name, sql: `${this.quote(name)} TEXT` };
+		this.columns.push(col);
+		const self = this;
+		const withUnique = Object.assign(self, {
+			unique() {
+				col.unique = true;
+				return self;
+			},
+		});
+		return withUnique as unknown as ColumnBuilder & TableBuilder;
+	}
+
+	boolean(name: string): TableBuilder {
+		// SQLite doesn't have BOOLEAN; use INTEGER 0/1
+		this.columns.push({ name, sql: `${this.quote(name)} INTEGER` });
+		return this;
+	}
+
+	timestamps(): TableBuilder {
+		this.columns.push({
+			name: "createdAt",
+			sql: `${this.quote("createdAt")} TEXT`,
+		});
+		this.columns.push({
+			name: "updatedAt",
+			sql: `${this.quote("updatedAt")} TEXT`,
+		});
+		return this;
+	}
+
+	unique(column: string | string[]): TableBuilder {
+		const cols = Array.isArray(column) ? column : [column];
+		this.uniqueConstraints.push(cols);
+		return this;
+	}
+
+	index(column: string | string[]): TableBuilder {
+		const columns = Array.isArray(column) ? column : [column];
+		this.indexes.push({ columns });
+		return this;
+	}
+
+	private quote(name: string): string {
+		return `"${name.replace(/"/g, '""')}"`;
+	}
+
+	/**
+	 * Build CREATE TABLE SQL
+	 */
+	toCreateSql(): string {
+		const parts: string[] = [];
+		for (const col of this.columns) {
+			let def = col.sql;
+			if (col.unique) {
+				def += " UNIQUE";
+			}
+			parts.push(def);
+		}
+		for (const cols of this.uniqueConstraints) {
+			const quoted = cols.map((c) => this.quote(c)).join(", ");
+			parts.push(`UNIQUE (${quoted})`);
+		}
+		const body = parts.join(", ");
+		return `CREATE TABLE ${this.quote(this.tableName)} (${body})`;
+	}
+
+	/**
+	 * Build CREATE INDEX statements for indexes defined on the table
+	 */
+	toIndexSql(): string[] {
+		const statements: string[] = [];
+		for (let i = 0; i < this.indexes.length; i++) {
+			const idx = this.indexes[i];
+			const indexName = `${this.tableName}_${idx.columns.join("_")}_index`;
+			const columns = idx.columns.map((c) => this.quote(c)).join(", ");
+			statements.push(
+				`CREATE INDEX ${this.quote(indexName)} ON ${this.quote(this.tableName)} (${columns})`,
+			);
+		}
+		return statements;
+	}
+
+	/**
+	 * For alter: return column definitions to add
+	 */
+	getAlterColumns(): ColumnDef[] {
+		return this.columns;
+	}
+
+	getTableName(): string {
+		return this.tableName;
+	}
+
+	getIsAlter(): boolean {
+		return this.isAlter;
+	}
+}

--- a/src/schema/types.ts
+++ b/src/schema/types.ts
@@ -1,0 +1,42 @@
+/**
+ * Schema builder types
+ */
+
+/**
+ * Fluent column builder for chaining modifiers (e.g. .unique())
+ */
+export interface ColumnBuilder {
+	/** Add UNIQUE constraint to the column */
+	unique(): ColumnBuilder;
+}
+
+/**
+ * Table builder interface for defining table schema
+ */
+export interface TableBuilder {
+	/** Auto-incrementing integer primary key */
+	increments(name: string): TableBuilder;
+
+	/** Integer column */
+	integer(name: string): TableBuilder;
+
+	/** Text column */
+	text(name: string): ColumnBuilder & TableBuilder;
+
+	/** Boolean column (stored as integer 0/1 in SQLite) */
+	boolean(name: string): TableBuilder;
+
+	/** Add createdAt and updatedAt timestamp columns */
+	timestamps(): TableBuilder;
+
+	/** Add UNIQUE constraint (standalone or on last column) */
+	unique(column: string | string[]): TableBuilder;
+
+	/** Create index on column(s) */
+	index(column: string | string[]): TableBuilder;
+}
+
+/**
+ * Callback type for table definition
+ */
+export type TableBuilderCallback = (table: TableBuilder) => void;

--- a/tests/schema-builder.test.ts
+++ b/tests/schema-builder.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Schema Builder Tests
+ */
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { Schema, getDriver, resetDriver, setOrmConfig } from "../src/index.js";
+
+describe("Schema Builder", () => {
+	const testDbPath = `/tmp/test-schema-${Date.now()}.sqlite`;
+
+	beforeEach(() => {
+		setOrmConfig({
+			database: {
+				type: "sqlite" as const,
+				sqlite: { path: testDbPath },
+			},
+		});
+	});
+
+	afterEach(async () => {
+		resetDriver();
+		try {
+			await Bun.file(testDbPath).unlink();
+		} catch {
+			// ignore
+		}
+	});
+
+	describe("Schema.createTable()", () => {
+		it("should create a table with increments id", () => {
+			Schema.createTable("users", (table) => {
+				table.increments("id");
+				table.text("name");
+			});
+
+			const driver = getDriver();
+			const result = driver
+				.query(
+					"SELECT name FROM sqlite_master WHERE type='table' AND name='users'",
+				)
+				.get();
+			expect(result).not.toBeNull();
+			expect(result?.name).toBe("users");
+
+			// Verify columns
+			const info = driver.query("PRAGMA table_info(users)").all();
+			expect(info.length).toBeGreaterThanOrEqual(2);
+			const idCol = info.find((c) => (c as { name: string }).name === "id");
+			expect(idCol).toBeDefined();
+			expect(idCol?.pk).toBe(1);
+		});
+
+		it("should create a table with integer, text, boolean columns", () => {
+			Schema.createTable("posts", (table) => {
+				table.increments("id");
+				table.integer("user_id");
+				table.text("title");
+				table.text("body");
+				table.boolean("published");
+			});
+
+			const driver = getDriver();
+			const info = driver.query("PRAGMA table_info(posts)").all();
+			expect(info.length).toBe(5);
+			const columns = info.map((c) => (c as { name: string }).name);
+			expect(columns).toContain("id");
+			expect(columns).toContain("user_id");
+			expect(columns).toContain("title");
+			expect(columns).toContain("body");
+			expect(columns).toContain("published");
+		});
+
+		it("should create a table with timestamps()", () => {
+			Schema.createTable("items", (table) => {
+				table.increments("id");
+				table.text("name");
+				table.timestamps();
+			});
+
+			const driver = getDriver();
+			const info = driver.query("PRAGMA table_info(items)").all();
+			const columns = info.map((c) => (c as { name: string }).name);
+			expect(columns).toContain("createdAt");
+			expect(columns).toContain("updatedAt");
+		});
+
+		it("should create a table with unique constraint", () => {
+			Schema.createTable("users_unique", (table) => {
+				table.increments("id");
+				table.text("email").unique();
+			});
+
+			const driver = getDriver();
+			const indexes = driver
+				.query(
+					"SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='users_unique'",
+				)
+				.all();
+			expect(indexes.length).toBeGreaterThanOrEqual(1);
+		});
+
+		it("should create a table with index()", () => {
+			Schema.createTable("posts_indexed", (table) => {
+				table.increments("id");
+				table.integer("user_id");
+				table.text("title");
+				table.index("user_id");
+			});
+
+			const driver = getDriver();
+			const indexes = driver
+				.query(
+					"SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='posts_indexed'",
+				)
+				.all();
+			expect(indexes.length).toBeGreaterThanOrEqual(1);
+		});
+	});
+
+	describe("Schema.dropTable()", () => {
+		it("should drop an existing table", () => {
+			Schema.createTable("to_drop", (table) => {
+				table.increments("id");
+			});
+
+			const driver = getDriver();
+			let result = driver
+				.query(
+					"SELECT name FROM sqlite_master WHERE type='table' AND name='to_drop'",
+				)
+				.get();
+			expect(result).not.toBeNull();
+
+			Schema.dropTable("to_drop");
+
+			result = driver
+				.query(
+					"SELECT name FROM sqlite_master WHERE type='table' AND name='to_drop'",
+				)
+				.get();
+			expect(result).toBeNull();
+		});
+	});
+
+	describe("Schema.table() (alter)", () => {
+		it("should support adding column via table()", () => {
+			Schema.createTable("alter_test", (table) => {
+				table.increments("id");
+				table.text("name");
+			});
+
+			Schema.table("alter_test", (table) => {
+				table.text("email");
+			});
+
+			const driver = getDriver();
+			const info = driver.query("PRAGMA table_info(alter_test)").all();
+			const columns = info.map((c) => (c as { name: string }).name);
+			expect(columns).toContain("email");
+		});
+	});
+});


### PR DESCRIPTION
Implements feature #15 - Schema builder (SQLite) for migrations.

## Context

Migrations need a schema builder to express DDL changes in TypeScript. This issue introduces the Schema builder API for SQLite only (no migration file discovery or runner).

## API

- `Schema.createTable(name, (table) => { ... })` - create table with fluent TableBuilder
- `Schema.dropTable(name)` - drop table if exists
- `Schema.table(name, (table) => { ... })` - alter table (add columns)

TableBuilder methods:
- `increments("id")` - INTEGER PRIMARY KEY AUTOINCREMENT
- `integer("col")` - INTEGER
- `text("col")` - TEXT (returns chainable for `.unique()`)
- `boolean("col")` - INTEGER (0/1 in SQLite)
- `timestamps()` - adds createdAt, updatedAt TEXT columns
- `unique("col")` / `unique(["a", "b"])` - UNIQUE constraint
- `index("col")` / `index(["a", "b"])` - CREATE INDEX

## Implementation

- SQLite implementation in `src/schema/`: SqliteTableBuilder collects definitions and emits SQL
- Schema uses getDriver() (or optional driver arg) to execute DDL
- CREATE TABLE, DROP TABLE IF EXISTS, ALTER TABLE ADD COLUMN, CREATE INDEX

## Testing

- 7 tests: create (increments, column types, timestamps, unique, index), drop, alter
- All 171 tests passing

## Documentation

- README.md and docs/index.md updated with schema builder examples
- CHANGELOG.md updated for v0.0.9

Closes #15
