### PR TITLE
feat(orm): migrations repository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.10] - 2026-01-29
+
+### Added
+
+- **Migrations repository** - Track applied migrations and support rollback
+  - `MigrationsRepository` - Ensures `migrations` table, logs applied migrations by name and batch
+  - `ensureTable()` - Create migrations table if missing (idempotent)
+  - `log(name, batch)` - Record an applied migration
+  - `listApplied()` - List all applied migrations ordered by id
+  - `getNextBatchNumber()` - Next batch number (max(batch)+1 or 1)
+  - `getLastBatch()` - Migrations in the last batch
+  - `deleteLog(name)` - Remove one migration record (rollback single)
+  - `deleteBatch(batch)` - Remove all records in a batch (rollback batch)
+  - `MigrationRecord` type exported
+  - SQLite-compatible; uses configured driver
+
 ## [0.0.9] - 2026-01-29
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -479,6 +479,37 @@ Schema.dropTable("users");
 
 **TableBuilder methods:** `increments("id")`, `integer("col")`, `text("col")`, `boolean("col")`, `timestamps()`, `unique("col")` / `unique(["a", "b"])`, `index("col")` / `index(["a", "b"])`. Use `text("col").unique()` for a unique text column.
 
+### Migrations Repository
+
+Track which migrations have been applied using `MigrationsRepository`. It ensures a `migrations` table exists, records applied migrations by name and batch, and supports listing and rollback.
+
+```typescript
+import { MigrationsRepository, setOrmConfig } from "@bunary/orm";
+
+setOrmConfig({
+  database: {
+    type: "sqlite",
+    sqlite: { path: "./database.sqlite" }
+  }
+});
+
+const repo = new MigrationsRepository();
+repo.ensureTable(); // Create migrations table if missing (idempotent)
+
+// Run a migration, then log it
+// ... execute migration SQL ...
+repo.log("20260101000000_create_users", repo.getNextBatchNumber());
+
+// List applied migrations (ordered by id)
+const applied = repo.listApplied();
+
+// Rollback: delete one migration record or a whole batch
+repo.deleteLog("20260101000000_create_users");
+repo.deleteBatch(2); // Remove all migrations in batch 2
+```
+
+**API:** `ensureTable()`, `log(name, batch)`, `listApplied()`, `getNextBatchNumber()`, `getLastBatch()`, `deleteLog(name)`, `deleteBatch(batch)`.
+
 ## Advanced Usage
 
 ### Direct Driver Access

--- a/docs/index.md
+++ b/docs/index.md
@@ -160,6 +160,32 @@ Schema.dropTable("users");
 
 TableBuilder: `increments("id")`, `integer()`, `text()`, `boolean()`, `timestamps()`, `unique()`, `index()`.
 
+## Migrations Repository
+
+Track which migrations have been applied. Ensures a `migrations` table, records applied migrations by name and batch, and supports listing and rollback.
+
+```ts
+import { MigrationsRepository, setOrmConfig } from "@bunary/orm";
+
+setOrmConfig({
+  database: {
+    type: "sqlite",
+    sqlite: { path: "./database.sqlite" },
+  },
+});
+
+const repo = new MigrationsRepository();
+repo.ensureTable();
+
+repo.log("20260101000000_create_users", repo.getNextBatchNumber());
+const applied = repo.listApplied();
+
+repo.deleteLog("20260101000000_create_users");
+repo.deleteBatch(2);
+```
+
+API: `ensureTable()`, `log(name, batch)`, `listApplied()`, `getNextBatchNumber()`, `getLastBatch()`, `deleteLog(name)`, `deleteBatch(batch)`.
+
 ## Requirements
 
 - Bun ≥ 1.0.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bunary/orm",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "ORM for Bunary - a Bun-first backend framework inspired by Laravel",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,6 +69,10 @@ export { BaseModel } from "./basemodel.js";
 export { Schema } from "./schema/index.js";
 export type { TableBuilder, TableBuilderCallback } from "./schema/index.js";
 
+// Migrations repository
+export { MigrationsRepository } from "./migrations/index.js";
+export type { MigrationRecord } from "./migrations/index.js";
+
 // Database Drivers
 export { SqliteDriver, MysqlDriver } from "./drivers/index.js";
 export type { DatabaseDriver, QueryResult } from "./drivers/types.js";

--- a/src/migrations/index.ts
+++ b/src/migrations/index.ts
@@ -1,0 +1,5 @@
+/**
+ * Migrations repository exports
+ */
+export { MigrationsRepository } from "./repository.js";
+export type { MigrationRecord } from "./types.js";

--- a/src/migrations/repository.ts
+++ b/src/migrations/repository.ts
@@ -1,0 +1,130 @@
+/**
+ * Migrations repository - tracks which migrations have been applied.
+ *
+ * Ensures the `migrations` table exists, records applied migrations,
+ * and supports querying status and rollback (delete log).
+ */
+
+import { getDriver } from "../connection.js";
+import type { DatabaseDriver } from "../drivers/types.js";
+import type { MigrationRecord } from "./types.js";
+
+const TABLE_NAME = "migrations";
+
+/**
+ * Migrations repository for tracking applied migrations.
+ *
+ * Uses the currently configured driver. Creates the migrations table
+ * if missing. SQLite-compatible.
+ *
+ * @example
+ * ```ts
+ * const repo = new MigrationsRepository();
+ * repo.ensureTable();
+ * repo.log("20260101000000_create_users", repo.getNextBatchNumber());
+ * const applied = repo.listApplied();
+ * repo.deleteBatch(2); // rollback batch 2
+ * ```
+ */
+export class MigrationsRepository {
+	private driver?: DatabaseDriver;
+
+	constructor(driver?: DatabaseDriver) {
+		this.driver = driver;
+	}
+
+	private getDb(): DatabaseDriver {
+		return this.driver ?? getDriver();
+	}
+
+	/**
+	 * Ensure the migrations table exists (create if missing).
+	 * Idempotent - safe to call multiple times.
+	 */
+	ensureTable(): void {
+		const db = this.getDb();
+		db.exec(`
+			CREATE TABLE IF NOT EXISTS ${TABLE_NAME} (
+				id INTEGER PRIMARY KEY AUTOINCREMENT,
+				name TEXT NOT NULL,
+				batch INTEGER NOT NULL,
+				applied_at TEXT NOT NULL
+			)
+		`);
+	}
+
+	/**
+	 * Record an applied migration
+	 *
+	 * @param name - Migration name (e.g. filename)
+	 * @param batch - Batch number
+	 */
+	log(name: string, batch: number): void {
+		const db = this.getDb();
+		const appliedAt = new Date().toISOString();
+		db.exec(
+			`INSERT INTO ${TABLE_NAME} (name, batch, applied_at) VALUES (?, ?, ?)`,
+			name,
+			batch,
+			appliedAt,
+		);
+	}
+
+	/**
+	 * List all applied migrations, ordered by id
+	 */
+	listApplied(): MigrationRecord[] {
+		const db = this.getDb();
+		const rows = db
+			.query(
+				`SELECT id, name, batch, applied_at FROM ${TABLE_NAME} ORDER BY id`,
+			)
+			.all();
+		return rows as unknown as MigrationRecord[];
+	}
+
+	/**
+	 * Get the next batch number (max(batch) + 1, or 1 if none)
+	 */
+	getNextBatchNumber(): number {
+		const db = this.getDb();
+		const row = db
+			.query(`SELECT COALESCE(MAX(batch), 0) as max_batch FROM ${TABLE_NAME}`)
+			.get();
+		const max = (row as { max_batch: number })?.max_batch ?? 0;
+		return max + 1;
+	}
+
+	/**
+	 * List migrations in the last (highest) batch
+	 */
+	getLastBatch(): MigrationRecord[] {
+		const db = this.getDb();
+		const rows = db
+			.query(
+				`SELECT id, name, batch, applied_at FROM ${TABLE_NAME} WHERE batch = (SELECT MAX(batch) FROM ${TABLE_NAME}) ORDER BY id`,
+			)
+			.all();
+		return rows as unknown as MigrationRecord[];
+	}
+
+	/**
+	 * Delete a migration record by name (for rollback of single migration)
+	 *
+	 * @param name - Migration name to remove from log
+	 */
+	deleteLog(name: string): void {
+		const db = this.getDb();
+		db.exec(`DELETE FROM ${TABLE_NAME} WHERE name = ?`, name);
+	}
+
+	/**
+	 * Delete all migration records in a batch (for rollback batch)
+	 *
+	 * @param batch - Batch number to remove
+	 */
+	deleteBatch(batch: number): void {
+		const db = this.getDb();
+		db.exec(`DELETE FROM ${TABLE_NAME} WHERE batch = ?`, batch);
+	}
+}

--- a/src/migrations/types.ts
+++ b/src/migrations/types.ts
@@ -1,0 +1,17 @@
+/**
+ * Migrations repository types
+ */
+
+/**
+ * Record of an applied migration
+ */
+export interface MigrationRecord {
+	/** Primary key */
+	id: number;
+	/** Migration name (e.g. filename or migration name) */
+	name: string;
+	/** Batch number (increments per run) */
+	batch: number;
+	/** When the migration was applied (ISO timestamp) */
+	applied_at: string;
+}

--- a/tests/migrations-repository.test.ts
+++ b/tests/migrations-repository.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Migrations Repository Tests
+ */
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import {
+	MigrationsRepository,
+	getDriver,
+	resetDriver,
+	setOrmConfig,
+} from "../src/index.js";
+
+describe("MigrationsRepository", () => {
+	const testDbPath = `/tmp/test-migrations-repo-${Date.now()}.sqlite`;
+
+	beforeEach(() => {
+		setOrmConfig({
+			database: {
+				type: "sqlite" as const,
+				sqlite: { path: testDbPath },
+			},
+		});
+	});
+
+	afterEach(async () => {
+		resetDriver();
+		try {
+			await Bun.file(testDbPath).unlink();
+		} catch {
+			// ignore
+		}
+	});
+
+	describe("ensureTable()", () => {
+		it("should create migrations table if missing", () => {
+			const repo = new MigrationsRepository();
+			repo.ensureTable();
+
+			const driver = getDriver();
+			const result = driver
+				.query(
+					"SELECT name FROM sqlite_master WHERE type='table' AND name='migrations'",
+				)
+				.get();
+			expect(result).not.toBeNull();
+			expect((result as { name: string }).name).toBe("migrations");
+		});
+
+		it("should be idempotent (safe to call multiple times)", () => {
+			const repo = new MigrationsRepository();
+			repo.ensureTable();
+			repo.ensureTable();
+			repo.ensureTable();
+
+			const driver = getDriver();
+			const info = driver.query("PRAGMA table_info(migrations)").all();
+			expect(info.length).toBeGreaterThanOrEqual(4);
+			const columns = info.map((c) => (c as { name: string }).name);
+			expect(columns).toContain("id");
+			expect(columns).toContain("name");
+			expect(columns).toContain("batch");
+			expect(columns).toContain("applied_at");
+		});
+	});
+
+	describe("log()", () => {
+		it("should record an applied migration", () => {
+			const repo = new MigrationsRepository();
+			repo.ensureTable();
+			repo.log("20260101000000_create_users_table", 1);
+
+			const driver = getDriver();
+			const rows = driver.query("SELECT * FROM migrations").all();
+			expect(rows.length).toBe(1);
+			expect((rows[0] as { name: string }).name).toBe(
+				"20260101000000_create_users_table",
+			);
+			expect((rows[0] as { batch: number }).batch).toBe(1);
+		});
+
+		it("should record multiple migrations in same batch", () => {
+			const repo = new MigrationsRepository();
+			repo.ensureTable();
+			repo.log("migration_a", 1);
+			repo.log("migration_b", 1);
+
+			const rows = repo.listApplied();
+			expect(rows.length).toBe(2);
+			expect(rows[0].batch).toBe(1);
+			expect(rows[1].batch).toBe(1);
+		});
+	});
+
+	describe("listApplied()", () => {
+		it("should return empty array when no migrations", () => {
+			const repo = new MigrationsRepository();
+			repo.ensureTable();
+
+			const rows = repo.listApplied();
+			expect(rows).toEqual([]);
+		});
+
+		it("should return applied migrations ordered by id", () => {
+			const repo = new MigrationsRepository();
+			repo.ensureTable();
+			repo.log("second", 1);
+			repo.log("first", 1);
+
+			const rows = repo.listApplied();
+			expect(rows.length).toBe(2);
+			// Insertion order: id 1 = "second", id 2 = "first"
+			expect(rows[0].name).toBe("second");
+			expect(rows[1].name).toBe("first");
+		});
+	});
+
+	describe("getNextBatchNumber()", () => {
+		it("should return 1 when no migrations", () => {
+			const repo = new MigrationsRepository();
+			repo.ensureTable();
+
+			expect(repo.getNextBatchNumber()).toBe(1);
+		});
+
+		it("should return 2 when batch 1 exists", () => {
+			const repo = new MigrationsRepository();
+			repo.ensureTable();
+			repo.log("migration_1", 1);
+
+			expect(repo.getNextBatchNumber()).toBe(2);
+		});
+
+		it("should return max batch + 1 when multiple batches", () => {
+			const repo = new MigrationsRepository();
+			repo.ensureTable();
+			repo.log("a", 1);
+			repo.log("b", 2);
+			repo.log("c", 2);
+
+			expect(repo.getNextBatchNumber()).toBe(3);
+		});
+	});
+
+	describe("getLastBatch()", () => {
+		it("should return empty array when no migrations", () => {
+			const repo = new MigrationsRepository();
+			repo.ensureTable();
+
+			expect(repo.getLastBatch()).toEqual([]);
+		});
+
+		it("should return migrations in the last batch", () => {
+			const repo = new MigrationsRepository();
+			repo.ensureTable();
+			repo.log("a", 1);
+			repo.log("b", 2);
+			repo.log("c", 2);
+
+			const last = repo.getLastBatch();
+			expect(last.length).toBe(2);
+			expect(last.map((r) => r.name).sort()).toEqual(["b", "c"]);
+			expect(last[0].batch).toBe(2);
+		});
+	});
+
+	describe("deleteLog() (rollback)", () => {
+		it("should delete a migration by name", () => {
+			const repo = new MigrationsRepository();
+			repo.ensureTable();
+			repo.log("to_rollback", 1);
+			repo.log("to_keep", 1);
+
+			repo.deleteLog("to_rollback");
+
+			const rows = repo.listApplied();
+			expect(rows.length).toBe(1);
+			expect(rows[0].name).toBe("to_keep");
+		});
+
+		it("should delete all migrations in a batch", () => {
+			const repo = new MigrationsRepository();
+			repo.ensureTable();
+			repo.log("a", 1);
+			repo.log("b", 2);
+			repo.log("c", 2);
+
+			repo.deleteBatch(2);
+
+			const rows = repo.listApplied();
+			expect(rows.length).toBe(1);
+			expect(rows[0].name).toBe("a");
+		});
+	});
+});


### PR DESCRIPTION
Closes #16

- MigrationsRepository: ensure migrations table, log applied migrations, list/getNextBatchNumber/getLastBatch, deleteLog/deleteBatch
- MigrationRecord type exported
- 13 tests, docs and CHANGELOG updated, version 0.0.10