### PR TITLE
chore: release 0.1.0 - first minor release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- First minor release — API stable for production use
+- First minor release — API stable for development use until 1.0.0
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.0] - 2026-01-31
+
+### Added
+
+- First minor release — API stable for production use
+
+### Changed
+
+- Bumped `@bunary/core` peer and dev dependency to ^0.1.0
+
 ## [0.0.14] - 2026-01-29
 
 ### Changed

--- a/biome.json
+++ b/biome.json
@@ -1,8 +1,6 @@
 {
-  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
-  "organizeImports": {
-    "enabled": true
-  },
+  "$schema": "https://biomejs.dev/schemas/2.3.13/schema.json",
+  "assist": { "actions": { "source": { "organizeImports": "on" } } },
   "linter": {
     "enabled": true,
     "rules": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bunary/orm",
-  "version": "0.0.14",
+  "version": "0.1.0",
   "description": "ORM for Bunary - a Bun-first backend framework inspired by Laravel",
   "type": "module",
   "main": "./dist/index.js",
@@ -47,12 +47,12 @@
     "bun": ">=1.0.0"
   },
   "peerDependencies": {
-    "@bunary/core": "^0.0.7"
+    "@bunary/core": "^0.1.0"
   },
   "devDependencies": {
-    "@bunary/core": "^0.0.7",
-    "@biomejs/biome": "^1.9.4",
-    "@types/bun": "1.3.6",
+    "@bunary/core": "^0.1.0",
+    "@biomejs/biome": "^2.3.13",
+    "@types/bun": "1.3.7",
     "bun-types": "latest",
     "typescript": "^5.7.3"
   }

--- a/src/config.ts
+++ b/src/config.ts
@@ -102,7 +102,6 @@ function tryGetCoreConfig(): OrmConfig | null {
 
 		// Method 3: Try import.meta.require (Bun runtime feature)
 		try {
-			// @ts-ignore - Bun runtime feature
 			import.meta.require?.(coreModuleId);
 			// No global config access in new API - config stores are instance-scoped
 		} catch {
@@ -111,7 +110,7 @@ function tryGetCoreConfig(): OrmConfig | null {
 
 		// Method 4: Try __require (Bun's internal require)
 		try {
-			// @ts-ignore - Bun internal
+			// @ts-expect-error - Bun internal
 			__require?.(coreModuleId);
 			// No global config access in new API - config stores are instance-scoped
 		} catch {

--- a/src/drivers/index.ts
+++ b/src/drivers/index.ts
@@ -1,6 +1,7 @@
 /**
  * Database Drivers
  */
+
+export { type MysqlConfig, MysqlDriver } from "./mysql-driver.js";
 export { SqliteDriver } from "./sqlite-driver.js";
-export { MysqlDriver, type MysqlConfig } from "./mysql-driver.js";
 export type { DatabaseDriver, QueryResult } from "./types.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,6 +41,7 @@
  * ```
  */
 
+export { BaseModel } from "./basemodel.js";
 // Configuration
 export {
 	clearOrmConfig,
@@ -49,49 +50,45 @@ export {
 	getOrmConfig,
 	setOrmConfig,
 } from "./config.js";
-
 // Connection Management
 export {
-	createDriver,
-	getDriver,
-	registerDriver,
 	clearDriverRegistry,
 	closeDriver,
-	resetDriver,
+	createDriver,
 	type DriverFactory,
+	getDriver,
+	registerDriver,
+	resetDriver,
 } from "./connection.js";
-
+// Database Drivers
+export { MysqlDriver, SqliteDriver } from "./drivers/index.js";
+export type { DatabaseDriver, QueryResult } from "./drivers/types.js";
+export type {
+	MigrationModule,
+	MigrationRecord,
+	MigrationStatus,
+	MigratorOptions,
+} from "./migrations/index.js";
+// Migrations repository
+// Migrator runner
+export {
+	createMigrator,
+	MigrationsRepository,
+	Migrator,
+} from "./migrations/index.js";
 // Model
 export { Model } from "./model.js";
-export { BaseModel } from "./basemodel.js";
-
+export type { TableBuilder, TableBuilderCallback } from "./schema/index.js";
 // Schema builder
 export { Schema } from "./schema/index.js";
-export type { TableBuilder, TableBuilderCallback } from "./schema/index.js";
-
-// Migrations repository
-export { MigrationsRepository } from "./migrations/index.js";
-export type { MigrationRecord } from "./migrations/index.js";
-
-// Migrator runner
-export { createMigrator, Migrator } from "./migrations/index.js";
-export type {
-	MigratorOptions,
-	MigrationStatus,
-	MigrationModule,
-} from "./migrations/index.js";
-
-// Database Drivers
-export { SqliteDriver, MysqlDriver } from "./drivers/index.js";
-export type { DatabaseDriver, QueryResult } from "./drivers/types.js";
 
 // Types
 export type {
-	DatabaseType,
 	DatabaseConfig,
-	SqliteConfig,
+	DatabaseType,
+	ModelData,
 	MysqlConfig,
 	OrmConfig,
-	ModelData,
 	QueryBuilder,
+	SqliteConfig,
 } from "./types.js";

--- a/src/migrations/index.ts
+++ b/src/migrations/index.ts
@@ -1,15 +1,15 @@
 /**
  * Migrations repository exports
  */
-export { MigrationsRepository } from "./repository.js";
-export type { MigrationRecord } from "./types.js";
 
+export type {
+	MigrationModule,
+	MigrationStatus,
+	MigratorOptions,
+} from "./migrator.js";
 /**
  * Migrator runner exports
  */
 export { createMigrator, Migrator } from "./migrator.js";
-export type {
-	MigratorOptions,
-	MigrationStatus,
-	MigrationModule,
-} from "./migrator.js";
+export { MigrationsRepository } from "./repository.js";
+export type { MigrationRecord } from "./types.js";

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -6,7 +6,7 @@ import { Database } from "bun:sqlite";
  * Verifies the abstraction layer works end-to-end
  */
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
-import { Model, createDriver, getDriver, setOrmConfig } from "../src/index.js";
+import { createDriver, getDriver, Model, setOrmConfig } from "../src/index.js";
 import type { DatabaseConfig, OrmConfig } from "../src/types.js";
 
 describe("ORM Integration - Full Flow", () => {

--- a/tests/migrations-repository.test.ts
+++ b/tests/migrations-repository.test.ts
@@ -3,8 +3,8 @@
  */
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import {
-	MigrationsRepository,
 	getDriver,
+	MigrationsRepository,
 	resetDriver,
 	setOrmConfig,
 } from "../src/index.js";

--- a/tests/migrator.test.ts
+++ b/tests/migrator.test.ts
@@ -3,8 +3,8 @@
  */
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import {
-	MigrationsRepository,
 	getDriver,
+	MigrationsRepository,
 	resetDriver,
 	setOrmConfig,
 } from "../src/index.js";

--- a/tests/schema-builder.test.ts
+++ b/tests/schema-builder.test.ts
@@ -2,7 +2,7 @@
  * Schema Builder Tests
  */
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { Schema, getDriver, resetDriver, setOrmConfig } from "../src/index.js";
+import { getDriver, resetDriver, Schema, setOrmConfig } from "../src/index.js";
 
 describe("Schema Builder", () => {
 	const testDbPath = `/tmp/test-schema-${Date.now()}.sqlite`;


### PR DESCRIPTION
Closes #35

## Changes
- Bump version to 0.1.0
- Bump `@bunary/core` peer and dev dependency to ^0.1.0
- Update CHANGELOG: first minor release — API stable for production use